### PR TITLE
quote path variables when used in shell commands

### DIFF
--- a/bin/ffyml
+++ b/bin/ffyml
@@ -30,40 +30,40 @@ output_file=$2
 temp_out="/tmp/ffinfo.tmp"
 
 # run ffmpeg in a known error state and capture it's file properties output from standard error
-echo "ffmpeg -i $video_file 2> $temp_out"
+echo "ffmpeg -i \"$video_file\" 2> \"$temp_out\""
 ffmpeg -i "$video_file" 2> "$temp_out"
 
 # parse temp_out for the file properties
 # format
-var_format=`cat $temp_out | grep "Input #0" | gawk -F', ' '{print $2}'`
-var_duration=`cat $temp_out | grep "Duration:" | gawk -F': ' '{print $2}' | gawk -F', ' '{print $1}'`
-var_bitrate=`cat $temp_out | grep "Duration:" | gawk -F': ' '{print $4}' | gawk -F' ' '{print $1}'`
-var_codec=`cat $temp_out | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $1}'`
-var_width=`cat $temp_out | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $3}' | gawk -F'x' '{print $1}'`
-var_height=`cat $temp_out | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $3}' | gawk -F'x' '{print $2}' | gawk -F' ' '{print $1}'`
-var_framerate=`cat $temp_out | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $5}' | gawk -F' ' '{print $1}'`
+var_format=`cat "$temp_out" | grep "Input #0" | gawk -F', ' '{print $2}'`
+var_duration=`cat "$temp_out" | grep "Duration:" | gawk -F': ' '{print $2}' | gawk -F', ' '{print $1}'`
+var_bitrate=`cat "$temp_out" | grep "Duration:" | gawk -F': ' '{print $4}' | gawk -F' ' '{print $1}'`
+var_codec=`cat "$temp_out" | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $1}'`
+var_width=`cat "$temp_out" | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $3}' | gawk -F'x' '{print $1}'`
+var_height=`cat "$temp_out" | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $3}' | gawk -F'x' '{print $2}' | gawk -F' ' '{print $1}'`
+var_framerate=`cat "$temp_out" | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $5}' | gawk -F' ' '{print $1}'`
 if [ "$var_framerate" = "" ]; then
-  var_framerate=`cat $temp_out | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $4}' | gawk -F' ' '{print $1}'`
+  var_framerate=`cat "$temp_out" | grep "Video:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $4}' | gawk -F' ' '{print $1}'`
 fi
-var_audio_codec=`cat $temp_out | grep "Audio:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $1}'`
-var_audio_bitrate=`cat $temp_out | grep "Audio:" | gawk -F', ' '{print $5}' | gawk -F' ' '{print $1}'`
-var_audio_sampling=`cat $temp_out | grep "Audio:" | gawk -F', ' '{print $2}' | gawk -F' ' '{print $1}'`
+var_audio_codec=`cat "$temp_out" | grep "Audio:" | gawk -F': ' '{print $3}' | gawk -F', ' '{print $1}'`
+var_audio_bitrate=`cat "$temp_out" | grep "Audio:" | gawk -F', ' '{print $5}' | gawk -F' ' '{print $1}'`
+var_audio_sampling=`cat "$temp_out" | grep "Audio:" | gawk -F', ' '{print $2}' | gawk -F' ' '{print $1}'`
 
 # write the output YAML file
-echo "# file properties" > $output_file
-echo format: $var_format >> $output_file
-echo duration: $var_duration >> $output_file
-echo bitrate: $var_bitrate >> $output_file
-echo codec: $var_codec >> $output_file
-echo width: $var_width >> $output_file
-echo height: $var_height >> $output_file
-echo framerate: $var_framerate >> $output_file
-echo audio_codec: $var_audio_codec >> $output_file
-echo audio_bitrate: $var_audio_bitrate >> $output_file
-echo audio_sampling: $var_audio_sampling >> $output_file
+echo "# file properties" > "$output_file"
+echo "format: $var_format" >> "$output_file"
+echo "duration: $var_duration" >> "$output_file"
+echo "bitrate: $var_bitrate" >> "$output_file"
+echo "codec: $var_codec" >> "$output_file"
+echo "width: $var_width" >> "$output_file"
+echo "height: $var_height" >> "$output_file"
+echo "framerate: $var_framerate" >> "$output_file"
+echo "audio_codec: $var_audio_codec" >> "$output_file"
+echo "audio_bitrate: $var_audio_bitrate" >> "$output_file"
+echo "audio_sampling: $var_audio_sampling" >> "$output_file"
 
 # cleanup
-rm $temp_out
+rm "$temp_out"
 
 echo "Done."
 

--- a/lib/pruview/video.rb
+++ b/lib/pruview/video.rb
@@ -63,8 +63,12 @@ module Pruview
     end
 
     def get_info(yml_path)
-      run("#{FFYML} #{@source} #{yml_path}", "Unable to get video info")
+      run(info_command(@source, yml_path), "Unable to get video info")
       YAML.load_file(yml_path)
+    end
+
+    def info_command(source, yml_path)
+      %Q{#{FFYML} "#{source}" "#{yml_path}"}
     end
 
     def build_command(source, target, width, height, info, scale_static)

--- a/lib/pruview/video_image.rb
+++ b/lib/pruview/video_image.rb
@@ -28,7 +28,7 @@ module Pruview
     end
     
     def self.build_command(source, time_str, format, target)
-      command = "#{Video::FFMPEG} -i #{source}"
+      command = %Q{#{Video::FFMPEG} -i "#{source}"}
       command += " #{time_str}"
       command += " -f #{format}" if !format.empty?
       command += " -an -y #{target}"

--- a/test/unit/video_image_test.rb
+++ b/test/unit/video_image_test.rb
@@ -23,6 +23,12 @@ module Pruview
         assert_equal '.jpg', File.extname(@output)
       end
 
+      should "quote the source path in #build_command" do
+        source = 'foo bar.jpg'
+        command = Pruview::VideoImage.build_command(source, 'a', 'b', 'c')
+        assert_equal 'ffmpeg -i "foo bar.jpg" a -f b -an -y c', command
+      end
+
     end
 
   end

--- a/test/unit/video_test.rb
+++ b/test/unit/video_test.rb
@@ -39,6 +39,11 @@ module Pruview
         assert_equal '.jpg', File.extname(@output)
       end
 
+      should "quote the source and yml_path args to the ffyml command" do
+        command = @file.send(:info_command, 'foo bar.jpg', 'foo bar.yml')
+        assert_equal %Q{#{Pruview::Video::FFYML} "foo bar.jpg" "foo bar.yml"}, command
+      end
+
     end
 
   end


### PR DESCRIPTION
This fixes the errors that were happening when a video file had spaces in its path.
