### PR TITLE
always set RGB colorspace

### DIFF
--- a/lib/pruview/document.rb
+++ b/lib/pruview/document.rb
@@ -83,14 +83,11 @@ module Pruview
 
     def set_RGB_colorspace(image)
       colorspace = run_system_command("identify #{GLOBAL_CMD_ARGS} -format \"%r\" #{image.path}", "Error reading document colorspace")
-      puts "Colorspace: #{colorspace}"
-      if colorspace =~ /CMYK/
-        image.combine_options do |img|
-          img.args << GLOBAL_CMD_ARGS
-          img.profile File.join(File.dirname(__FILE__), 'USWebCoatedSWOP.icc')
-          img.profile File.join(File.dirname(__FILE__), 'sRGB.icm')
-          img.colorspace 'sRGB'
-        end
+      image.combine_options do |img|
+        img.args << GLOBAL_CMD_ARGS
+        img.profile File.join(File.dirname(__FILE__), 'USWebCoatedSWOP.icc')
+        img.profile File.join(File.dirname(__FILE__), 'sRGB.icm')
+        img.colorspace 'sRGB'
       end
     end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,14 +14,14 @@ FILES_PATH = "./test/files"
 OUTPUT_PATH = "./test_output"
 INVALID_OUTPUT_PATH = "./test_output/invalid"
 FILES = {
-  'basic image' => "./test/files/basic.jpg",
-  'invalid image' => "./test/files/invalid.jpg",
-  'error image' => "./test/files/error.jpg",
-  'basic video' => "./test/files/basic.mpg",
-  'invalid video' => "./test/files/invalid.mov",
-  'error video' => "./test/files/error.mov",
+  'basic image'    => "./test/files/basic.jpg",
+  'invalid image'  => "./test/files/invalid.jpg",
+  'error image'    => "./test/files/error.jpg",
+  'basic video'    => "./test/files/basic.mpg",
+  'invalid video'  => "./test/files/invalid.mov",
+  'error video'    => "./test/files/error.mov",
   'invalid format' => "./test/files/invalid_format.poop",
-  'tiff' => "./test/files/image.tiff"
+  'tiff'           => "./test/files/image.tiff"
 }
 
 FileUtils.mkdir_p File.expand_path(FILES_PATH) unless File.exists? File.expand_path(FILES_PATH)


### PR DESCRIPTION
This forces the colorspace of output images to always be RGB,
regardless of input format.  This has no effect on images that are
already RGB, but sets all other non-rgb formats (not just cmyk).

@jcredding ready for review.
